### PR TITLE
Mobility GHC927 updates

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+nix_direnv_watch_file \
+    *.cabal
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ result
 result-*
 tags
 stack.yaml.lock
+.direnv/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  .

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1684780604,
-        "narHash": "sha256-2uMZsewmRn7rRtAnnQNw1lj0uZBMh4m6Cs/7dV5YF08=",
+        "lastModified": 1686160859,
+        "narHash": "sha256-UE+0TQHyPxF8jhbLEeqvNQAy7B79bBix/rpFrf5nsn0=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "74210fa80a49f1b6f67223debdbf1494596ff9f2",
+        "rev": "908a59167f78035a123ab71ed77af79bed519771",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "0.3.0",
         "repo": "haskell-flake",
+        "rev": "908a59167f78035a123ab71ed77af79bed519771",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    haskell-flake.url = "github:srid/haskell-flake/0.3.0";
+    # haskell-flake 0.4.0 unreleased, points to latest master commit at the time
+    haskell-flake.url = "github:srid/haskell-flake/908a59167f78035a123ab71ed77af79bed519771";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
@@ -13,11 +14,11 @@
       perSystem = { self', pkgs, lib, config, ... }: {
         packages.default = self'.packages.juspay-extra;
         haskellProjects.default = {
-          overrides = self: super:
-            with pkgs.haskell.lib.compose;
-            lib.mapAttrs (k: v: lib.pipe super.${k} v) {
-              juspay-extra = [ doJailbreak ];
+          settings = {
+            juspay-extra = {
+              jailbreak = true;
             };
+          };
         };
       };
     });

--- a/juspay-extra.cabal
+++ b/juspay-extra.cabal
@@ -25,7 +25,7 @@ common common-lang
 
   build-depends:
     , base                     >=4.13   && <5
-    , record-dot-preprocessor  ^>=0.2.14
+    , record-dot-preprocessor
     , record-hasfield
 
   default-extensions:
@@ -77,7 +77,7 @@ library
     , optics-core
     , QuickCheck
     , reflection
-    , servant                    ^>= 0.18.3
+    , servant
     , store
     , string-conversions
     , text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,10 @@
 
-resolver: lts-18.7
+resolver: lts-20.18
 
 
 packages:
 - .
 
 extra-deps:
-- record-dot-preprocessor-0.2.14
+- text-format-0.3.2.1
+- validation-selective-0.2.0.0


### PR DESCRIPTION
This PR makes the changes to bring the repo up-to date for use with the mobility set of projects.

Key changes:-

* Updates haskell-flake to new 0.4.0 (unreleased atm) version and syntax.
* General Quality of Life updates like adding .envrc file, updating gitignore, adding a cabal.project file etc.

